### PR TITLE
Add Live Site Link to README (Cloudflare Deployment)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## Live Site
+
+🚀 View the deployed site: https://nscth-static-website.pages.dev
+
 # Base Structure Setup
 
 # NSC Tech Hub Static Website


### PR DESCRIPTION
Closes #3 

This pull request updates the project README to include a link to the live deployed site hosted on Cloudflare Pages.

## Changes

* Added a **Live Site** section to the README
* Included the deployed URL for easy access: [https://nscth-static-website.pages.dev/](https://nscth-static-website.pages.dev)

## Purpose

This improves project visibility and makes it easier for users and reviewers to quickly access the deployed version of the application.