### PR TITLE
feat: Set Up Global Layout & Navigation (closes #2)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,16 @@
 <footer class="border-t border-white/10 bg-slate-950">
-  <div class="mx-auto max-w-screen-lg px-4 py-6 text-sm text-slate-400">
-    <p class="leading-relaxed text-center md:text-left">
-      © 2026 NSC Tech Hub. Built by Students at North Seattle College.
-    </p>
+  <div class="mx-auto max-w-screen-lg px-4 py-8 text-sm text-slate-400">
+    <div class="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+      <p class="leading-relaxed text-center md:text-left">
+        © 2026 NSC Tech Hub. Built by Students at North Seattle College.
+      </p>
+      <nav class="flex flex-wrap justify-center gap-x-6 gap-y-2 md:justify-end">
+        <a href="/" class="transition hover:text-white">Home</a>
+        <a href="/services" class="transition hover:text-white">Services</a>
+        <a href="/team" class="transition hover:text-white">Team</a>
+        <a href="/contact" class="transition hover:text-white">Contact</a>
+        <a href="https://github.com/NSC-Tech-Hub" class="transition hover:text-white" target="_blank" rel="noopener">GitHub</a>
+      </nav>
+    </div>
   </div>
 </footer>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,7 @@
 ---
 import "../styles/global.css";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
 
 const {
     title = "NSC Tech Hub",
@@ -17,8 +19,10 @@ const {
 </head>
 
 <body class="min-h-screen bg-slate-950 text-white antialiased">
+    <Header />
     <main class="mx-auto max-w-screen-lg px-4 py-6">
         <slot />
     </main>
+    <Footer />
 </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,15 +1,10 @@
----
-import Header from "../components/Header.astro";
-import Footer from "../components/Footer.astro";
-import BaseLayout from "../layouts/BaseLayout.astro";
+---import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
 <BaseLayout
 	title="NSC Tech Hub"
 	description="The technical engine for Bridge to Tech at North Seattle College."
 >
-	<Header />
-
 	<main>
 
 		<!-- ─── HERO ────────────────────────────────────────────────── -->
@@ -317,5 +312,4 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
 	</main>
 
-	<Footer />
 </BaseLayout>


### PR DESCRIPTION
## Summary
Wires Header and Footer into BaseLayout.astro so all pages get the nav and footer automatically via the layout slot.

## Changes
- `BaseLayout.astro` — imports and renders Header and Footer around the slot
- `Footer.astro` — adds placeholder links: Home, Services, Team, Contact, GitHub
- `index.astro` — removes manual Header/Footer imports since layout handles them

## Acceptance Criteria
- ✅ All pages use layout
- ✅ Navbar works on mobile + desktop
- ✅ Footer has placeholder links
- ✅ Mobile-first design