### PR TITLE
feat: add custom 404 page using BaseLayout (closes #37)

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,23 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+
+<BaseLayout title="404 — Page Not Found" description="The page you are looking for does not exist.">
+  <section class="flex min-h-[70vh] flex-col items-center justify-center px-4 py-24 text-center">
+    <p class="text-sm font-semibold uppercase tracking-[0.25em] text-blue-300">
+      404 Error
+    </p>
+    <h1 class="mt-4 text-6xl font-bold tracking-tight text-white sm:text-8xl">
+      404
+    </h1>
+    <p class="mt-4 text-xl font-semibold text-white">
+      Page Not Found
+    </p>
+    <p class="mt-4 max-w-md text-base text-slate-400">
+      The page you are looking for does not exist or has been moved.
+    </p>
+    <a href="/" class="mt-8 rounded-lg bg-blue-600 px-6 py-3 font-semibold text-white transition hover:-translate-y-0.5 hover:bg-blue-500 hover:shadow-lg hover:shadow-blue-500/25">
+      Back to Home
+    </a>
+  </section>
+</BaseLayout>


### PR DESCRIPTION
<img width="320" height="321" alt="404" src="https://github.com/user-attachments/assets/9f304277-63bf-46a4-82f6-45cd336288aa" />

## Summary
Creates a custom 404 error page that displays when a user navigates to a URL that does not exist on the site.

## Changes
- `src/pages/404.astro` — custom 404 page using BaseLayout for consistent header and footer

## How to Test
1. Run the project locally:
   npm run dev
2. Navigate to any invalid URL:
   http://localhost:5173/this-does-not-exist
3. Confirm the 404 page renders with header, footer, error message, and Back to Home link

## Acceptance Criteria
- ✅ Navigating to any invalid URL shows the custom 404 page
- ✅ Page uses the global layout (header + footer visible)
- ✅ Page includes a working link back to home
- ✅ Page is styled consistently with the site design