### PR TITLE
feat: sync header navigation to match footer links (closes #44)

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,13 +2,13 @@
   <div class="header-inner">
     <a href="/" class="logo">NSC Tech Hub</a>
 
-    <nav class="nav-links">
-      <a href="/">Home</a>
-      <a href="/#architecture">Architecture</a>
-      <a href="/#stage">Stage</a>
-      <a href="/contact">Contact</a>
-      <a href="/services">Services</a>
-    </nav>
+<nav class="nav-links">
+  <a href="/">Home</a>
+  <a href="/services">Services</a>
+  <a href="/team">Team</a>
+  <a href="/contact">Contact</a>
+  <a href="https://github.com/NSC-Tech-Hub" target="_blank" rel="noopener">GitHub</a>
+</nav>
   </div>
 </header>
 


### PR DESCRIPTION
Closes #44

- Removed /#architecture and /#stage anchor links
- Added /team and GitHub (external) to match footer navigation
- Link order matches footer: Home, Services, Team, Contact, GitHub
- No style or layout changes