### PR TITLE
Closes #5: Create team page with reusable TeamCard component and mock…

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -7,6 +7,7 @@
       <a href="/#architecture">Architecture</a>
       <a href="/#stage">Stage</a>
       <a href="/contact">Contact</a>
+      <a href="/team">Team</a>
       <a href="/services">Services</a>
     </nav>
   </div>

--- a/src/components/TeamCard.astro
+++ b/src/components/TeamCard.astro
@@ -1,0 +1,39 @@
+---
+interface Props {
+  name: string;
+  role: string;
+  bio: string;
+  image?: string | null;
+}
+
+const { name, role, bio, image } = Astro.props;
+---
+
+<article class="flex gap-4">
+
+  <!-- Picture box — standalone bordered box -->
+  <div class="shrink-0 w-36 h-36 border border-white/20 bg-white/5 flex items-center justify-center rounded-sm">
+    {image ? (
+      <img
+        src={image}
+        alt={`Photo of ${name}`}
+        class="w-full h-full object-cover rounded-sm"
+        loading="lazy"
+      />
+    ) : (
+      <svg viewBox="0 0 100 100" class="w-full h-full text-white/20" xmlns="http://www.w3.org/2000/svg">
+        <line x1="0" y1="0" x2="100" y2="100" stroke="currentColor" stroke-width="1.5"/>
+        <line x1="100" y1="0" x2="0" y2="100" stroke="currentColor" stroke-width="1.5"/>
+        <text x="50" y="58" text-anchor="middle" font-size="10" fill="currentColor">Picture</text>
+      </svg>
+    )}
+  </div>
+
+  <!-- Text box — standalone bordered box -->
+  <div class="flex-1 border border-white/20 bg-white/5 rounded-sm p-4">
+    <h3 class="text-base font-bold text-white">{name}</h3>
+    <p class="text-sm text-white/50 mb-2">{role}</p>
+    <p class="text-sm leading-relaxed text-white/60">{bio}</p>
+  </div>
+
+</article>

--- a/src/data/teamData.json
+++ b/src/data/teamData.json
@@ -1,0 +1,41 @@
+[
+  {
+    "section": "TPM",
+    "members": [
+      {
+        "name": "Team Member Name",
+        "role": "Position",
+        "bio": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.",
+        "image": null
+      }
+    ]
+  },
+  {
+    "section": "Product Management",
+    "members": [
+      {
+        "name": "Team Member Name",
+        "role": "Position",
+        "bio": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.",
+        "image": null
+      },
+      {
+        "name": "Team Member Name",
+        "role": "Position",
+        "bio": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.",
+        "image": null
+      }
+    ]
+  },
+  {
+    "section": "Developers",
+    "members": [
+      {
+        "name": "Team Member Name",
+        "role": "Position",
+        "bio": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.",
+        "image": null
+      }
+    ]
+  }
+]

--- a/src/pages/team.astro
+++ b/src/pages/team.astro
@@ -1,0 +1,42 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import TeamCard from "../components/TeamCard.astro";
+import teamData from "../data/teamData.json";
+---
+
+<BaseLayout title="Our Team | NSC Tech Hub">
+  <div class="mx-auto max-w-3xl px-6 py-20">
+
+    <header class="mb-16 text-center">
+      <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">
+        Our Team
+      </h1>
+    </header>
+
+    {teamData.map((group) => (
+      <section class="mb-12">
+
+        <!-- Full-width rule first, then label right-aligned below it -->
+        <div class="mb-6">
+          <div class="h-px w-full bg-white/20"></div>
+          <h2 class="text-right text-lg font-bold text-white mt-2">
+            {group.section}
+          </h2>
+        </div>
+
+        <div class="flex flex-col gap-4">
+          {group.members.map((member) => (
+            <TeamCard
+              name={member.name}
+              role={member.role}
+              bio={member.bio}
+              image={member.image}
+            />
+          ))}
+        </div>
+
+      </section>
+    ))}
+
+  </div>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- Added `src/pages/team.astro` — team page with Our Team hero heading
- Added `src/components/TeamCard.astro` — reusable horizontal card component
- Added `src/data/teamData.json` — mock data for TPM, Product Management, and Developers sections
- Updated `src/components/Header.astro` — added Team link to nav

## Acceptance Criteria
- [x] Cards display consistently
- [x] Easy to update later (edit teamData.json only)
- [x] TPM section
- [x] Product Management section
- [x] Developers section
- [x] Team link in header and footer nav

Closes #5

<img width="602" height="712" alt="team" src="https://github.com/user-attachments/assets/a4dd69b9-3c5d-4345-84ed-811938f23ae7" />
