### PR TITLE
Closes #39: Add logo placeholder to header and fix orphaned anchor tag

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,7 +1,17 @@
 <header class="site-header">
   <div class="header-inner">
-    <a href="/" class="logo">NSC Tech Hub</a>
-
+    <a href="/" class="logo" aria-label="NSC Tech Hub Home">
+      <!--
+        ISSUE #39 — Logo placeholder using Logo.png
+        When tech-hub-logo.svg is available, replace the img src with:
+        /src/assets/tech-hub-logo.svg
+      -->
+      <img
+        src="/Logo.png"
+        alt="NSC Tech Hub Home"
+        class="logo-img"
+      />
+    </a>
     <nav class="nav-links">
       <a href="/">Home</a>
       <a href="/#architecture">Architecture</a>
@@ -11,13 +21,11 @@
     </nav>
   </div>
 </header>
-
 <style>
   .site-header {
     background: #050816;
     border-bottom: 1px solid #1e293b;
   }
-
   .header-inner {
     max-width: 1200px;
     margin: 0 auto;
@@ -26,35 +34,32 @@
     align-items: center;
     justify-content: space-between;
   }
-
   .logo {
-    color: white;
-    font-weight: 800;
-    font-size: 1.25rem;
     text-decoration: none;
+    display: flex;
+    align-items: center;
   }
-
+  .logo-img {
+    height: 2.5rem;
+    width: auto;
+  }
   .nav-links {
     display: flex;
     gap: 1.5rem;
   }
-
   .nav-links a {
     color: #cbd5e1;
     text-decoration: none;
     font-weight: 500;
   }
-
   .nav-links a:hover {
     color: white;
   }
-
   @media (max-width: 700px) {
     .header-inner {
       flex-direction: column;
       gap: 1rem;
     }
-
     .nav-links {
       flex-wrap: wrap;
       justify-content: center;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,11 +30,8 @@ import Gallery from "../components/Gallery.astro";
 					Creative, Business, and Technical disciplines through student-led digital
 					solutions at North Seattle College.
 				</p>
-            <a
-	href="#join"
-	class="rounded-lg bg-blue-600 px-6 py-3 text-center font-semibold text-white transition hover:-translate-y-0.5 hover:bg-blue-500 hover:shadow-lg hover:shadow-blue-500/25"
-<div class="mt-8 flex flex-col gap-3 sm:mt-10 sm:flex-row sm:flex-wrap sm:gap-4">
 
+<div class="mt-8 flex flex-col gap-3 sm:mt-10 sm:flex-row sm:flex-wrap sm:gap-4">
 	<a
 		href="#join"
 		class="rounded-lg bg-blue-600 px-6 py-3 text-center font-semibold text-white transition hover:-translate-y-0.5 hover:bg-blue-500 hover:shadow-lg hover:shadow-blue-500/25"


### PR DESCRIPTION
## Summary
- Updated `src/components/Header.astro` — replaced text title with `Logo.png` placeholder wrapped in `<a>` tag routing to `/`
- Added `alt="NSC Tech Hub Home"` for accessibility
- Added CSS for responsive logo scaling across mobile and desktop
- Fixed orphaned/unclosed `<a>` tag in `src/pages/index.astro` that was causing a stray element in the hero section

## Notes
- `tech-hub-logo.svg` is not yet available — using `Logo.png` from `public/` as confirmed by @taylorpapke
- When SVG is ready, swap `src="/Logo.png"` with `src="/assets/tech-hub-logo.svg"` in `Header.astro`

## Acceptance Criteria
- [x] Logo image in header
- [x] Wrapped in `<a>` tag routing to `/`
- [x] Accessible alt text
- [x] Responsive scaling on mobile and desktop

Closes #39