### PR TITLE
fix: remove orphaned anchor tag causing stray button in hero

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,9 +30,6 @@ import Gallery from "../components/Gallery.astro";
 					Creative, Business, and Technical disciplines through student-led digital
 					solutions at North Seattle College.
 				</p>
-            <a
-	href="#join"
-	class="rounded-lg bg-blue-600 px-6 py-3 text-center font-semibold text-white transition hover:-translate-y-0.5 hover:bg-blue-500 hover:shadow-lg hover:shadow-blue-500/25"
 <div class="mt-8 flex flex-col gap-3 sm:mt-10 sm:flex-row sm:flex-wrap sm:gap-4">
 
 	<a

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,323 +2,462 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 import Gallery from "../components/Gallery.astro";
 ---
+
 <BaseLayout
-	title="NSC Tech Hub"
-	description="The technical engine for Bridge to Tech at North Seattle College."
+  title="NSC Tech Hub"
+  description="The technical engine for Bridge to Tech at North Seattle College."
 >
-	<main>
+  <main>
+    <!-- ─── HERO ────────────────────────────────────────────────── -->
 
-		<!-- ─── HERO ────────────────────────────────────────────────── -->
-		<section class="relative flex min-h-[90vh] flex-col justify-center px-4 py-24 sm:px-6 sm:py-28">
-			<div class="pointer-events-none absolute inset-0 bg-[linear-gradient(rgba(255,255,255,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.03)_1px,transparent_1px)] bg-[size:48px_48px] sm:bg-[size:72px_72px]"></div>
+    <section
+      class="relative flex min-h-[90vh] flex-col justify-center px-4 py-24 sm:px-6 sm:py-28"
+    >
+      <div
+        class="pointer-events-none absolute inset-0 bg-[linear-gradient(rgba(255,255,255,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.03)_1px,transparent_1px)] bg-[size:48px_48px] sm:bg-[size:72px_72px]"
+      >
+      </div>
 
-			<div class="relative mx-auto w-full max-w-6xl">
-				<div class="mb-6 inline-flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1.5 sm:px-4">
-					<span class="h-2 w-2 shrink-0 animate-pulse rounded-full bg-blue-400"></span>
-					<p class="text-xs font-semibold uppercase tracking-[0.15em] text-blue-300 sm:tracking-[0.2em]">
-						Stage 1.1 — Live Integration
-					</p>
-				</div>
+      <div class="relative mx-auto w-full max-w-6xl">
+        <div
+          class="mb-6 inline-flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1.5 sm:px-4"
+        >
+          <span class="h-2 w-2 shrink-0 animate-pulse rounded-full bg-blue-400"
+          ></span>
+          <p
+            class="text-xs font-semibold uppercase tracking-[0.15em] text-blue-300 sm:tracking-[0.2em]"
+          >
+            Stage 1.1 — Live Integration
+          </p>
+        </div>
 
-				<h1 class="mt-2 max-w-4xl text-4xl font-bold tracking-tight text-white sm:text-5xl md:text-7xl">
-					The Technical Engine for
-					<span class="text-blue-400"> Bridge to Tech</span>
-				</h1>
+        <h1
+          class="mt-2 max-w-4xl text-4xl font-bold tracking-tight text-white sm:text-5xl md:text-7xl"
+        >
+          The Technical Engine for
+          <span class="text-blue-400"> Bridge to Tech</span>
+        </h1>
 
-				<p class="mt-5 max-w-2xl text-base leading-7 text-slate-400 sm:mt-6 sm:text-lg sm:leading-8">
-					The NSC Tech Hub is an interdepartmental digital agency designed to bridge
-					Creative, Business, and Technical disciplines through student-led digital
-					solutions at North Seattle College.
-				</p>
-<div class="mt-8 flex flex-col gap-3 sm:mt-10 sm:flex-row sm:flex-wrap sm:gap-4">
+        <p
+          class="mt-5 max-w-2xl text-base leading-7 text-slate-400 sm:mt-6 sm:text-lg sm:leading-8"
+        >
+          The NSC Tech Hub is an interdepartmental digital agency designed to
+          bridge Creative, Business, and Technical disciplines through
+          student-led digital solutions at North Seattle College.
+        </p>
 
-	<a
-		href="#join"
-		class="rounded-lg bg-blue-600 px-6 py-3 text-center font-semibold text-white transition hover:-translate-y-0.5 hover:bg-blue-500 hover:shadow-lg hover:shadow-blue-500/25"
-	>
-		Join the Hub
-	</a>
+        <div
+          class="mt-8 flex flex-col gap-3 sm:mt-10 sm:flex-row sm:flex-wrap sm:gap-4"
+        >
+          <a
+            href="#join"
+            class="rounded-lg bg-blue-600 px-6 py-3 text-center font-semibold text-white transition hover:-translate-y-0.5 hover:bg-blue-500 hover:shadow-lg hover:shadow-blue-500/25"
+          >
+            Join the Hub
+          </a>
 
-	<a
-		href="#services"
-		class="rounded-lg border border-white/20 px-6 py-3 text-center font-semibold text-white transition hover:border-white/40 hover:bg-white/5"
-	>
-		Explore Services
-	</a>
+          <a
+            href="#services"
+            class="rounded-lg border border-white/20 px-6 py-3 text-center font-semibold text-white transition hover:border-white/40 hover:bg-white/5"
+          >
+            Explore Services
+          </a>
+        </div>
 
-</div>
+        <div
+          class="mt-12 grid grid-cols-2 gap-6 border-t border-white/10 pt-8 sm:mt-16 sm:flex sm:flex-wrap sm:gap-8"
+        >
+          <div>
+            <p class="text-2xl font-bold text-white">3</p>
+            <p class="mt-0.5 text-sm text-slate-400">Core Departments</p>
+          </div>
+          <div>
+            <p class="text-2xl font-bold text-white">RAG</p>
+            <p class="mt-0.5 text-sm text-slate-400">AI-Enhanced Ops</p>
+          </div>
+          <div>
+            <p class="text-2xl font-bold text-white">v1.1</p>
+            <p class="mt-0.5 text-sm text-slate-400">Live Integration</p>
+          </div>
+          <div>
+            <p class="text-2xl font-bold text-white">NSC</p>
+            <p class="mt-0.5 text-sm text-slate-400">North Seattle College</p>
+          </div>
+        </div>
+      </div>
+    </section>
 
-</div>
-				</div>
+    <!-- ─── MISSION ─────────────────────────────────────────────── -->
+    <section
+      id="mission"
+      class="border-t border-white/10 bg-slate-900/60 px-4 py-16 sm:px-6 sm:py-20"
+    >
+      <div class="mx-auto max-w-6xl">
+        <div class="max-w-2xl">
+          <p
+            class="text-sm font-semibold uppercase tracking-[0.25em] text-blue-300"
+          >
+            Mission Statement
+          </p>
+          <h2 class="mt-4 text-3xl font-bold text-white sm:text-4xl">
+            A system-dependent agency built to last.
+          </h2>
+          <p
+            class="mt-4 text-base leading-7 text-slate-400 sm:text-lg sm:leading-8"
+          >
+            The NSC Tech Hub operates as a system-dependent agency. We utilize a
+            "Tree Architecture" to ensure that institutional knowledge is
+            preserved and that cross-departmental collaboration across Art,
+            Business, and App Dev is frictionless.
+          </p>
+        </div>
 
-				<div class="mt-12 grid grid-cols-2 gap-6 border-t border-white/10 pt-8 sm:mt-16 sm:flex sm:flex-wrap sm:gap-8">
-					<div>
-						<p class="text-2xl font-bold text-white">3</p>
-						<p class="mt-0.5 text-sm text-slate-400">Core Departments</p>
-					</div>
-					<div>
-						<p class="text-2xl font-bold text-white">RAG</p>
-						<p class="mt-0.5 text-sm text-slate-400">AI-Enhanced Ops</p>
-					</div>
-					<div>
-						<p class="text-2xl font-bold text-white">v1.1</p>
-						<p class="mt-0.5 text-sm text-slate-400">Live Integration</p>
-					</div>
-					<div>
-						<p class="text-2xl font-bold text-white">NSC</p>
-						<p class="mt-0.5 text-sm text-slate-400">North Seattle College</p>
-					</div>
-				</div>
-			</div>
-		</section>
+        <div class="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <article
+            class="rounded-2xl border border-white/10 bg-white/5 p-5 transition hover:border-blue-500/30 hover:bg-blue-500/5 sm:p-6"
+          >
+            <div
+              class="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10 text-xl"
+            >
+              🧭
+            </div>
+            <h3 class="text-base font-semibold text-white">
+              Technical Program Manager
+            </h3>
+            <p class="mt-2 text-sm leading-6 text-slate-400">
+              Acts as the Trunk. Translates stakeholder requirements into
+              technical specs, manages the GitHub Organization, and oversees the
+              Vetting Loop.
+            </p>
+          </article>
 
-		<!-- ─── MISSION ─────────────────────────────────────────────── -->
-		<section id="mission" class="border-t border-white/10 bg-slate-900/60 px-4 py-16 sm:px-6 sm:py-20">
-			<div class="mx-auto max-w-6xl">
-				<div class="max-w-2xl">
-					<p class="text-sm font-semibold uppercase tracking-[0.25em] text-blue-300">
-						Mission Statement
-					</p>
-					<h2 class="mt-4 text-3xl font-bold text-white sm:text-4xl">
-						A system-dependent agency built to last.
-					</h2>
-					<p class="mt-4 text-base leading-7 text-slate-400 sm:text-lg sm:leading-8">
-						The NSC Tech Hub operates as a system-dependent agency. We utilize a "Tree Architecture"
-						to ensure that institutional knowledge is preserved and that cross-departmental
-						collaboration across Art, Business, and App Dev is frictionless.
-					</p>
-				</div>
+          <article
+            class="rounded-2xl border border-white/10 bg-white/5 p-5 transition hover:border-blue-500/30 hover:bg-blue-500/5 sm:p-6"
+          >
+            <div
+              class="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10 text-xl"
+            >
+              🏫
+            </div>
+            <h3 class="text-base font-semibold text-white">Faculty Owners</h3>
+            <p class="mt-2 text-sm leading-6 text-slate-400">
+              Institutional oversight and curriculum alignment. Ensure projects
+              meet academic standards and provide high-value learning outcomes
+              for students.
+            </p>
+          </article>
 
-				<div class="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-					<article class="rounded-2xl border border-white/10 bg-white/5 p-5 transition hover:border-blue-500/30 hover:bg-blue-500/5 sm:p-6">
-						<div class="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10 text-xl">
-							🧭
-						</div>
-						<h3 class="text-base font-semibold text-white">Technical Program Manager</h3>
-						<p class="mt-2 text-sm leading-6 text-slate-400">
-							Acts as the Trunk. Translates stakeholder requirements into technical specs,
-							manages the GitHub Organization, and oversees the Vetting Loop.
-						</p>
-					</article>
+          <article
+            class="rounded-2xl border border-white/10 bg-white/5 p-5 transition hover:border-blue-500/30 hover:bg-blue-500/5 sm:p-6"
+          >
+            <div
+              class="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10 text-xl"
+            >
+              🔗
+            </div>
+            <h3 class="text-base font-semibold text-white">
+              Department Liaisons
+            </h3>
+            <p class="mt-2 text-sm leading-6 text-slate-400">
+              Single point of contact for each team. Ensure assets meet Design
+              Specs before submission to the TPM.
+            </p>
+          </article>
 
-					<article class="rounded-2xl border border-white/10 bg-white/5 p-5 transition hover:border-blue-500/30 hover:bg-blue-500/5 sm:p-6">
-						<div class="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10 text-xl">
-							🏫
-						</div>
-						<h3 class="text-base font-semibold text-white">Faculty Owners</h3>
-						<p class="mt-2 text-sm leading-6 text-slate-400">
-							Institutional oversight and curriculum alignment. Ensure projects meet
-							academic standards and provide high-value learning outcomes for students.
-						</p>
-					</article>
+          <article
+            class="rounded-2xl border border-white/10 bg-white/5 p-5 transition hover:border-blue-500/30 hover:bg-blue-500/5 sm:p-6"
+          >
+            <div
+              class="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10 text-xl"
+            >
+              ⚙️
+            </div>
+            <h3 class="text-base font-semibold text-white">Production Teams</h3>
+            <p class="mt-2 text-sm leading-6 text-slate-400">
+              Students executing tasks across Coding, Design, and Marketing
+              within Team Repositories and established documentation.
+            </p>
+          </article>
+        </div>
 
-					<article class="rounded-2xl border border-white/10 bg-white/5 p-5 transition hover:border-blue-500/30 hover:bg-blue-500/5 sm:p-6">
-						<div class="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10 text-xl">
-							🔗
-						</div>
-						<h3 class="text-base font-semibold text-white">Department Liaisons</h3>
-						<p class="mt-2 text-sm leading-6 text-slate-400">
-							Single point of contact for each team. Ensure assets meet Design Specs
-							before submission to the TPM.
-						</p>
-					</article>
+        <div
+          class="mt-6 rounded-2xl border border-white/10 bg-white/5 p-5 sm:mt-8 sm:p-8"
+        >
+          <p
+            class="text-sm font-semibold uppercase tracking-[0.25em] text-blue-300"
+          >
+            Tree Architecture
+          </p>
+          <h3 class="mt-3 text-xl font-bold text-white sm:text-2xl">
+            How we are structured
+          </h3>
+          <div class="mt-6 grid grid-cols-1 gap-5 sm:grid-cols-3 sm:gap-6">
+            <div class="flex gap-4">
+              <div
+                class="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10 text-sm"
+              >
+                🌱
+              </div>
+              <div>
+                <h4 class="font-semibold text-white">Roots</h4>
+                <p class="mt-1 text-sm text-slate-400">
+                  Governance, source-of-truth documentation, and standardized
+                  guidebooks.
+                </p>
+              </div>
+            </div>
+            <div class="flex gap-4">
+              <div
+                class="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-amber-500/10 text-sm"
+              >
+                🪵
+              </div>
+              <div>
+                <h4 class="font-semibold text-white">Trunk</h4>
+                <p class="mt-1 text-sm text-slate-400">
+                  Technical program management that turns stakeholder needs into
+                  execution.
+                </p>
+              </div>
+            </div>
+            <div class="flex gap-4">
+              <div
+                class="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-blue-500/10 text-sm"
+              >
+                🌿
+              </div>
+              <div>
+                <h4 class="font-semibold text-white">Canopy</h4>
+                <p class="mt-1 text-sm text-slate-400">
+                  Cross-department collaboration between App Dev, Art, and
+                  Business.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
 
-					<article class="rounded-2xl border border-white/10 bg-white/5 p-5 transition hover:border-blue-500/30 hover:bg-blue-500/5 sm:p-6">
-						<div class="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10 text-xl">
-							⚙️
-						</div>
-						<h3 class="text-base font-semibold text-white">Production Teams</h3>
-						<p class="mt-2 text-sm leading-6 text-slate-400">
-							Students executing tasks across Coding, Design, and Marketing within
-							Team Repositories and established documentation.
-						</p>
-					</article>
-				</div>
+    <!-- ─── SERVICES ────────────────────────────────────────────── -->
+    <section
+      id="services"
+      class="border-t border-white/10 px-4 py-16 sm:px-6 sm:py-20"
+    >
+      <div class="mx-auto max-w-6xl">
+        <div
+          class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between"
+        >
+          <div>
+            <p
+              class="text-sm font-semibold uppercase tracking-[0.25em] text-blue-300"
+            >
+              What We Build
+            </p>
+            <h2 class="mt-4 text-3xl font-bold text-white sm:text-4xl">
+              Services & Departments
+            </h2>
+          </div>
+          <a
+            href="#join"
+            class="text-sm font-semibold text-blue-400 transition hover:text-blue-300"
+          >
+            Get involved →
+          </a>
+        </div>
 
-				<div class="mt-6 rounded-2xl border border-white/10 bg-white/5 p-5 sm:mt-8 sm:p-8">
-					<p class="text-sm font-semibold uppercase tracking-[0.25em] text-blue-300">
-						Tree Architecture
-					</p>
-					<h3 class="mt-3 text-xl font-bold text-white sm:text-2xl">How we are structured</h3>
-					<div class="mt-6 grid grid-cols-1 gap-5 sm:grid-cols-3 sm:gap-6">
-						<div class="flex gap-4">
-							<div class="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10 text-sm">
-								🌱
-							</div>
-							<div>
-								<h4 class="font-semibold text-white">Roots</h4>
-								<p class="mt-1 text-sm text-slate-400">Governance, source-of-truth documentation, and standardized guidebooks.</p>
-							</div>
-						</div>
-						<div class="flex gap-4">
-							<div class="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-amber-500/10 text-sm">
-								🪵
-							</div>
-							<div>
-								<h4 class="font-semibold text-white">Trunk</h4>
-								<p class="mt-1 text-sm text-slate-400">Technical program management that turns stakeholder needs into execution.</p>
-							</div>
-						</div>
-						<div class="flex gap-4">
-							<div class="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-blue-500/10 text-sm">
-								🌿
-							</div>
-							<div>
-								<h4 class="font-semibold text-white">Canopy</h4>
-								<p class="mt-1 text-sm text-slate-400">Cross-department collaboration between App Dev, Art, and Business.</p>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</section>
+        <div
+          class="mt-8 grid grid-cols-1 gap-5 sm:mt-10 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3"
+        >
+          <article
+            class="rounded-2xl border border-white/10 bg-white/5 p-5 transition hover:-translate-y-1 hover:border-blue-500/30 hover:shadow-lg hover:shadow-blue-500/5 sm:p-6"
+          >
+            <div
+              class="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-blue-500/10 text-2xl"
+            >
+              💻
+            </div>
+            <h3 class="text-lg font-semibold text-white">
+              App & AI Development
+            </h3>
+            <p class="mt-2 text-sm leading-6 text-slate-400">
+              Full SDLC development, AI integration, and RAG application
+              architecture built for North Seattle College's operational needs.
+            </p>
+            <div class="mt-4 flex flex-wrap gap-2">
+              <span
+                class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-400"
+                >Full SDLC</span
+              >
+              <span
+                class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-400"
+                >RAG</span
+              >
+              <span
+                class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-400"
+                >GitHub</span
+              >
+            </div>
+          </article>
 
-		<!-- ─── SERVICES ────────────────────────────────────────────── -->
-		<section id="services" class="border-t border-white/10 px-4 py-16 sm:px-6 sm:py-20">
-			<div class="mx-auto max-w-6xl">
-				<div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-					<div>
-						<p class="text-sm font-semibold uppercase tracking-[0.25em] text-blue-300">
-							What We Build
-						</p>
-						<h2 class="mt-4 text-3xl font-bold text-white sm:text-4xl">
-							Services & Departments
-						</h2>
-					</div>
-					<a href="#join" class="text-sm font-semibold text-blue-400 transition hover:text-blue-300">
-						Get involved →
-					</a>
-				</div>
+          <article
+            class="rounded-2xl border border-white/10 bg-white/5 p-5 transition hover:-translate-y-1 hover:border-blue-500/30 hover:shadow-lg hover:shadow-blue-500/5 sm:p-6"
+          >
+            <div
+              class="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-blue-500/10 text-2xl"
+            >
+              🎨
+            </div>
+            <h3 class="text-lg font-semibold text-white">Art & Design</h3>
+            <p class="mt-2 text-sm leading-6 text-slate-400">
+              UX research, asset creation, and artistic consistency across all
+              brand touchpoints and student-led initiatives.
+            </p>
+            <div class="mt-4 flex flex-wrap gap-2">
+              <span
+                class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-400"
+                >UX Research</span
+              >
+              <span
+                class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-400"
+                >Brand Identity</span
+              >
+              <span
+                class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-400"
+                >Assets</span
+              >
+            </div>
+          </article>
 
-				<div class="mt-8 grid grid-cols-1 gap-5 sm:mt-10 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3">
-					<article class="rounded-2xl border border-white/10 bg-white/5 p-5 transition hover:-translate-y-1 hover:border-blue-500/30 hover:shadow-lg hover:shadow-blue-500/5 sm:p-6">
-						<div class="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-blue-500/10 text-2xl">
-							💻
-						</div>
-						<h3 class="text-lg font-semibold text-white">App & AI Development</h3>
-						<p class="mt-2 text-sm leading-6 text-slate-400">
-							Full SDLC development, AI integration, and RAG application architecture
-							built for North Seattle College's operational needs.
-						</p>
-						<div class="mt-4 flex flex-wrap gap-2">
-							<span class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-400">Full SDLC</span>
-							<span class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-400">RAG</span>
-							<span class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-400">GitHub</span>
-						</div>
-					</article>
+          <article
+            class="rounded-2xl border border-white/10 bg-white/5 p-5 transition hover:-translate-y-1 hover:border-blue-500/30 hover:shadow-lg hover:shadow-blue-500/5 sm:p-6 sm:col-span-2 lg:col-span-1"
+          >
+            <div
+              class="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-blue-500/10 text-2xl"
+            >
+              📊
+            </div>
+            <h3 class="text-lg font-semibold text-white">
+              Business & Strategy
+            </h3>
+            <p class="mt-2 text-sm leading-6 text-slate-400">
+              Market validation, P&L modeling, and strategic planning to ensure
+              every initiative creates sustainable value for the community.
+            </p>
+            <div class="mt-4 flex flex-wrap gap-2">
+              <span
+                class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-400"
+                >Market Validation</span
+              >
+              <span
+                class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-400"
+                >P&L Modeling</span
+              >
+              <span
+                class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-400"
+                >Strategy</span
+              >
+            </div>
+          </article>
+        </div>
 
-					<article class="rounded-2xl border border-white/10 bg-white/5 p-5 transition hover:-translate-y-1 hover:border-blue-500/30 hover:shadow-lg hover:shadow-blue-500/5 sm:p-6">
-						<div class="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-blue-500/10 text-2xl">
-							🎨
-						</div>
-						<h3 class="text-lg font-semibold text-white">Art & Design</h3>
-						<p class="mt-2 text-sm leading-6 text-slate-400">
-							UX research, asset creation, and artistic consistency across all
-							brand touchpoints and student-led initiatives.
-						</p>
-						<div class="mt-4 flex flex-wrap gap-2">
-							<span class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-400">UX Research</span>
-							<span class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-400">Brand Identity</span>
-							<span class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-400">Assets</span>
-						</div>
-					</article>
+        <div
+          class="mt-5 flex items-start gap-4 rounded-2xl border border-white/10 bg-white/5 px-5 py-4 sm:mt-6 sm:items-center sm:px-6 sm:py-5"
+        >
+          <div
+            class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-500/10 text-xl"
+          >
+            🚀
+          </div>
+          <div>
+            <p class="font-semibold text-white">
+              Active Stage 1.1 — Live Integration
+            </p>
+            <p class="mt-1 text-sm text-slate-400 sm:mt-0">
+              Transitioning from person-dependent to system-dependent workflows
+              by codifying manual protocols into an automated source of truth.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
 
-					<article class="rounded-2xl border border-white/10 bg-white/5 p-5 transition hover:-translate-y-1 hover:border-blue-500/30 hover:shadow-lg hover:shadow-blue-500/5 sm:p-6 sm:col-span-2 lg:col-span-1">
-						<div class="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-blue-500/10 text-2xl">
-							📊
-						</div>
-						<h3 class="text-lg font-semibold text-white">Business & Strategy</h3>
-						<p class="mt-2 text-sm leading-6 text-slate-400">
-							Market validation, P&L modeling, and strategic planning to ensure
-							every initiative creates sustainable value for the community.
-						</p>
-						<div class="mt-4 flex flex-wrap gap-2">
-							<span class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-400">Market Validation</span>
-							<span class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-400">P&L Modeling</span>
-							<span class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-400">Strategy</span>
-						</div>
-					</article>
-				</div>
+    <!-- ─── JOIN / CTA ───────────────────────────────────────────── -->
+    <section
+      id="join"
+      class="border-t border-white/10 bg-slate-900/60 px-4 py-16 sm:px-6 sm:py-20"
+    >
+      <div class="mx-auto max-w-6xl">
+        <div
+          class="rounded-2xl border border-blue-500/20 bg-blue-500/5 px-5 py-12 text-center sm:px-8 sm:py-14"
+        >
+          <p
+            class="text-sm font-semibold uppercase tracking-[0.25em] text-blue-300"
+          >
+            Get Involved
+          </p>
 
-				<div class="mt-5 flex items-start gap-4 rounded-2xl border border-white/10 bg-white/5 px-5 py-4 sm:mt-6 sm:items-center sm:px-6 sm:py-5">
-					<div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-500/10 text-xl">
-						🚀
-					</div>
-					<div>
-						<p class="font-semibold text-white">Active Stage 1.1 — Live Integration</p>
-						<p class="mt-1 text-sm text-slate-400 sm:mt-0">
-							Transitioning from person-dependent to system-dependent workflows by codifying manual protocols into an automated source of truth.
-						</p>
-					</div>
-				</div>
-			</div>
-		</section>
+          <h2
+            class="mt-4 text-3xl font-bold text-white sm:text-4xl md:text-5xl"
+          >
+            Ready to join the Hub?
+          </h2>
 
-		<!-- ─── JOIN / CTA ───────────────────────────────────────────── -->
-		<section id="join" class="border-t border-white/10 bg-slate-900/60 px-4 py-16 sm:px-6 sm:py-20">
-			<div class="mx-auto max-w-6xl">
-				<div class="rounded-2xl border border-blue-500/20 bg-blue-500/5 px-5 py-12 text-center sm:px-8 sm:py-14">
-					<p class="text-sm font-semibold uppercase tracking-[0.25em] text-blue-300">
-						Get Involved
-					</p>
+          <p class="mx-auto mt-4 max-w-xl text-base text-slate-400 sm:text-lg">
+            Whether you're a student, faculty member, or community partner —
+            there's a place for you in the NSC Tech Hub ecosystem.
+          </p>
 
-					<h2 class="mt-4 text-3xl font-bold text-white sm:text-4xl md:text-5xl">
-						Ready to join the Hub?
-					</h2>
+          <div
+            class="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center sm:gap-4"
+          >
+            <a
+              href="mailto:techhub@northseattle.edu"
+              class="w-full rounded-lg bg-blue-600 px-8 py-3 font-semibold text-white transition hover:-translate-y-0.5 hover:bg-blue-500 hover:shadow-lg hover:shadow-blue-500/25 sm:w-auto"
+            >
+              Contact Us
+            </a>
 
-					<p class="mx-auto mt-4 max-w-xl text-base text-slate-400 sm:text-lg">
-						Whether you're a student, faculty member, or community partner —
-						there's a place for you in the NSC Tech Hub ecosystem.
-					</p>
+            <a
+              href="#services"
+              class="w-full rounded-lg border border-white/20 px-8 py-3 font-semibold text-white transition hover:border-white/40 hover:bg-white/5 sm:w-auto"
+            >
+              Learn More
+            </a>
+          </div>
 
-					<div class="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center sm:gap-4">
-						<a
-	href="mailto:techhub@northseattle.edu"
-	class="w-full rounded-lg bg-blue-600 px-8 py-3 font-semibold text-white transition hover:-translate-y-0.5 hover:bg-blue-500 hover:shadow-lg hover:shadow-blue-500/25 sm:w-auto"
->
-	Contact Us
-</a>
-
-<a
-	href="#services"
-	class="w-full rounded-lg border border-white/20 px-8 py-3 font-semibold text-white transition hover:border-white/40 hover:bg-white/5 sm:w-auto"
->
-	Learn More
-</a>
-					</div>
-
-					<div class="mt-10 grid grid-cols-1 gap-4 text-left sm:mt-12 sm:grid-cols-3">
-						<div class="rounded-xl border border-white/10 bg-white/5 p-5">
-							<p class="text-xl">🎓</p>
-							<h4 class="mt-3 font-semibold text-white">Students</h4>
-							<p class="mt-1 text-sm text-slate-400">
-								Join a production team in App Dev, Design, or Business.
-								Build a real portfolio on real projects.
-							</p>
-						</div>
-						<div class="rounded-xl border border-white/10 bg-white/5 p-5">
-							<p class="text-xl">🏫</p>
-							<h4 class="mt-3 font-semibold text-white">Faculty & Admins</h4>
-							<p class="mt-1 text-sm text-slate-400">
-								Serve in TPM oversight or as a Liaison Node admin.
-								Help shape the operational backbone of the Hub.
-							</p>
-						</div>
-						<div class="rounded-xl border border-white/10 bg-white/5 p-5">
-							<p class="text-xl">🤝</p>
-							<h4 class="mt-3 font-semibold text-white">Community Partners</h4>
-							<p class="mt-1 text-sm text-slate-400">
-								Collaborate through our external outreach programs
-								and innovation seedbed initiatives.
-							</p>
-						</div>
-					</div>
-				</div>
-			</div>
-		</section>
-			<!-- Reusable Gallery Component -->
-		<Gallery />
-
-	</main>
-
+          <div
+            class="mt-10 grid grid-cols-1 gap-4 text-left sm:mt-12 sm:grid-cols-3"
+          >
+            <div class="rounded-xl border border-white/10 bg-white/5 p-5">
+              <p class="text-xl">🎓</p>
+              <h4 class="mt-3 font-semibold text-white">Students</h4>
+              <p class="mt-1 text-sm text-slate-400">
+                Join a production team in App Dev, Design, or Business. Build a
+                real portfolio on real projects.
+              </p>
+            </div>
+            <div class="rounded-xl border border-white/10 bg-white/5 p-5">
+              <p class="text-xl">🏫</p>
+              <h4 class="mt-3 font-semibold text-white">Faculty & Admins</h4>
+              <p class="mt-1 text-sm text-slate-400">
+                Serve in TPM oversight or as a Liaison Node admin. Help shape
+                the operational backbone of the Hub.
+              </p>
+            </div>
+            <div class="rounded-xl border border-white/10 bg-white/5 p-5">
+              <p class="text-xl">🤝</p>
+              <h4 class="mt-3 font-semibold text-white">Community Partners</h4>
+              <p class="mt-1 text-sm text-slate-400">
+                Collaborate through our external outreach programs and
+                innovation seedbed initiatives.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <!-- Reusable Gallery Component -->
+    <Gallery />
+  </main>
 </BaseLayout>


### PR DESCRIPTION

### Problem
`index.astro` had an unclosed `<a>` tag in the hero section (lines 33–35).
It opened with `href="#join"` and button styling but never closed, which
rendered as a stray blue square next to the "Join the Hub" button.

### Fix
Deleted the orphaned 3-line `<a>` block. The real, working buttons are
already defined inside the `<div>` below it — nothing else changed.

### Testing
- Verified with `npm run dev` — stray blue square is gone
- "Join the Hub" button still works and jumps to #join
- 3-line deletion, no other changes