### PR TITLE
Closes #10: Add Open Graph and Twitter Card meta tags, add page descr…

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,25 +4,32 @@ import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 
 const {
-    title = "NSC Tech Hub",
-    description = "The technical engine for Bridge to Tech at North Seattle College.",
+  title = "NSC Tech Hub",
+  description = "The technical engine for Bridge to Tech at North Seattle College.",
 } = Astro.props;
 ---
 
 <!doctype html>
 <html lang="en">
-<head>
+  <head>
     <meta charset="UTF-8" />
     <meta name="description" content={description} />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{title}</title>
-</head>
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={Astro.url} />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+  </head>
 
-<body class="min-h-screen bg-slate-950 text-white antialiased">
+  <body class="min-h-screen bg-slate-950 text-white antialiased">
     <Header />
     <main class="mx-auto max-w-screen-lg px-4 py-6">
-        <slot />
+      <slot />
     </main>
     <Footer />
-</body>
+  </body>
 </html>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -2,7 +2,10 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
-<BaseLayout title="Contact | NSC Tech Hub">
+<BaseLayout
+  title="Contact | NSC Tech Hub"
+  description="Get in touch with NSC Tech Hub at North Seattle College."
+>
   <main class="contact-page">
     <section class="hero">
       <h1>Interested in Working with the Tech Hub?</h1>
@@ -26,10 +29,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         </div>
       </div>
 
-      <form
-        class="contact-form"
-        id="contact-form"
-      >
+      <form class="contact-form" id="contact-form">
         <label for="name">Name</label>
         <input
           id="name"
@@ -56,8 +56,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
           name="message"
           rows="6"
           placeholder="Type your message"
-          required
-        ></textarea>
+          required></textarea>
 
         <button type="submit" id="submit-btn">Send Message</button>
 
@@ -79,7 +78,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     }, 5000);
   };
 
-form.addEventListener("submit", async (e) => {
+  form.addEventListener("submit", async (e) => {
     e.preventDefault();
 
     if (button.disabled) return;

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -2,28 +2,43 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
-<BaseLayout>
+<BaseLayout
+  title="Services | NSC Tech Hub"
+  description="Explore the services offered by NSC Tech Hub at North Seattle College."
+>
   <main class="max-w-3xl mx-auto p-6">
     <h1 class="text-3xl font-bold mb-6">Our Services</h1>
 
     <section class="mb-6">
       <h2 class="text-xl font-semibold">Product Management</h2>
-      <p>We define product goals, prioritize features, and guide projects from concept to launch.</p>
+      <p>
+        We define product goals, prioritize features, and guide projects from
+        concept to launch.
+      </p>
     </section>
 
     <section class="mb-6">
       <h2 class="text-xl font-semibold">Development</h2>
-      <p>We build scalable and reliable web applications using modern technologies and best practices.</p>
+      <p>
+        We build scalable and reliable web applications using modern
+        technologies and best practices.
+      </p>
     </section>
 
     <section class="mb-6">
       <h2 class="text-xl font-semibold">Design Collaboration</h2>
-      <p>We collaborate with designers to create intuitive, accessible, and visually engaging user experiences.</p>
+      <p>
+        We collaborate with designers to create intuitive, accessible, and
+        visually engaging user experiences.
+      </p>
     </section>
 
     <section class="mb-6">
       <h2 class="text-xl font-semibold">Internal AD Support</h2>
-      <p>We support internal teams by providing tools, systems, and technical guidance to improve workflows.</p>
+      <p>
+        We support internal teams by providing tools, systems, and technical
+        guidance to improve workflows.
+      </p>
     </section>
   </main>
 </BaseLayout>

--- a/src/pages/team.astro
+++ b/src/pages/team.astro
@@ -4,7 +4,7 @@ import TeamCard from "../components/TeamCard.astro";
 import teamData from "../data/teamData.json";
 ---
 
-<BaseLayout title="Our Team | NSC Tech Hub">
+<BaseLayout title="Our Team | NSC Tech Hub" description="Meet the students building and running NSC Tech Hub at North Seattle College.">
   <div class="mx-auto max-w-3xl px-6 py-20">
 
     <header class="mb-16 text-center">


### PR DESCRIPTION
…iptionsSummary

Adds Open Graph and Twitter Card meta tags to BaseLayout.astro so all pages inherit proper SEO metadata. Also adds missing title and description props to pages that were using defaults.
Changes

Added og:title, og:description, og:type, og:url to BaseLayout <head>
Added twitter:card, twitter:title, twitter:description to BaseLayout <head>
Added title and description props to contact.astro, services.astro
Added description prop to team.astro

Notes

Clean rewrite of the SEO work from PR #34, isolated to only the changes required by Issue #10
No changes to any component logic, styling, or dependencies

Closes #10